### PR TITLE
Use petitparser 5.0.0

### DIFF
--- a/lib/src/ast/value/string/basic.dart
+++ b/lib/src/ast/value/string/basic.dart
@@ -46,9 +46,9 @@ class TomlBasicString extends TomlSinglelineString {
   ///  and `%x5C` which is the `escape` character `\`.
   static final Parser<String> unescapedParser = ChoiceParser([
     tomlWhitespaceChar,
-    char(0x21),
-    range(0x23, 0x5B),
-    range(0x5D, 0x7E),
+    char('\x21'),
+    range('\x23', '\x5B'),
+    range('\x5D', '\x7E'),
     tomlNonAscii
   ]).flatten('Basic string character expected');
 

--- a/lib/src/ast/value/string/literal.dart
+++ b/lib/src/ast/value/string/literal.dart
@@ -36,8 +36,8 @@ class TomlLiteralString extends TomlSinglelineString {
   /// (i.e., `%x27`).
   static final Parser<String> charParser = ChoiceParser([
     char('\x09'),
-    range(0x20, 0x26),
-    range(0x28, 0x7E),
+    range('\x20', '\x26'),
+    range('\x28', '\x7E'),
     tomlNonAscii,
   ]).flatten('Literal string character expected');
 

--- a/lib/src/ast/value/string/ml_basic.dart
+++ b/lib/src/ast/value/string/ml_basic.dart
@@ -76,9 +76,9 @@ class TomlMultilineBasicString extends TomlMultilineString {
   ///  and `%x5C` which is the `escape` character `\`.
   static final Parser<String> unescapedParser = ChoiceParser([
     tomlWhitespaceChar,
-    char(0x21),
-    range(0x23, 0x5B),
-    range(0x5D, 0x7E),
+    char('\x21'),
+    range('\x23', '\x5B'),
+    range('\x5D', '\x7E'),
     tomlNonAscii
   ]).flatten('Unescaped multiline basic string character expected');
 

--- a/lib/src/ast/value/string/ml_literal.dart
+++ b/lib/src/ast/value/string/ml_literal.dart
@@ -65,9 +65,9 @@ class TomlMultilineLiteralString extends TomlMultilineString {
   /// Literal strings can contain tabs (i.e., `%x09`) but no `apostrophe`s
   /// (i.e., `%x27`).
   static final Parser<String> contentParser = ChoiceParser([
-    char(0x09),
-    range(0x20, 0x26),
-    range(0x28, 0x7E),
+    char('\x09'),
+    range('\x20', '\x26'),
+    range('\x28', '\x7E'),
     tomlNonAscii,
     tomlNewline,
   ]).flatten('Multiline literal string character expected');

--- a/lib/src/decoder/parser/ranges.dart
+++ b/lib/src/decoder/parser/ranges.dart
@@ -24,7 +24,7 @@ Parser<String> tomlHexDigit([String message = 'hexadecimal digit expected']) =>
 ///
 ///     non-eol = %x09 / %x20-7E / non-ascii
 final Parser<String> tomlNonEol =
-    ChoiceParser([char(0x09), range(0x20, 0x7E), tomlNonAscii]);
+    ChoiceParser([char('\x09'), range('\x20', '\x7E'), tomlNonAscii]);
 
 /// Parser for non-ASCII characters that are allowed in TOML comments and
 /// literal strings.
@@ -35,8 +35,8 @@ final Parser<String> tomlNonEol =
 /// Since `petitparser` can only work with 16-Bit code units, we have to
 /// parse the surrogate pairs manually.
 final Parser<String> tomlNonAscii = ChoiceParser([
-  range(0x80, 0xD7FF),
-  range(0xE000, 0xFFFF),
+  range(String.fromCharCode(0x80), String.fromCharCode(0xD7FF)),
+  range(String.fromCharCode(0xE000), String.fromCharCode(0xFFFF)),
   _tomlSurrogatePair,
 ]);
 
@@ -47,7 +47,9 @@ final Parser<String> _tomlSurrogatePair =
     (_tomlHighSurrogate & _tomlLowSurrogate).flatten('Surrogate pair expected');
 
 /// Parser for high surrogates (`%xD800-DBFF`).
-final Parser<String> _tomlHighSurrogate = range(0xD800, 0xDBFF);
+final Parser<String> _tomlHighSurrogate =
+    range(String.fromCharCode(0xD800), String.fromCharCode(0xDBFF));
 
 /// Parser for low surrogates (`%xDC00-DFFF`).
-final Parser<String> _tomlLowSurrogate = range(0xDC00, 0xDFFF);
+final Parser<String> _tomlLowSurrogate =
+    range(String.fromCharCode(0xDC00), String.fromCharCode(0xDFFF));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 dependencies:
   meta: ^1.7.0
-  petitparser: ^4.2.0
+  petitparser: ^5.0.0
   collection: ^1.15.0
 dev_dependencies:
   lints: ^1.0.1


### PR DESCRIPTION
The `char` function from `petitparser` now takes a `String` as a parameter instead of an `Object`.

I run all tests and they pass.

@just95 @erf 