### PR TITLE
Exit bin/decoder.dart with code 1

### DIFF
--- a/bin/decoder.dart
+++ b/bin/decoder.dart
@@ -63,6 +63,13 @@ String serializeValue(dynamic value) {
 
 Future main() async {
   var input = await stdin.transform(utf8.decoder).join();
-  var document = TomlDocument.parse(input).toMap();
+  var document;
+
+  try {
+    document = TomlDocument.parse(input).toMap();
+  } on Exception catch (e) {
+    print('$e');
+    exit(1);
+  }
   print(json.encode(encodeTable(document)));
 }


### PR DESCRIPTION
I changed toml-test to only consider exactly exit 1 to be a passing "invalid" test as some encoders were segfaulting on some input, which usually shouldn't pass.

Previously it was exiting with 255.