### PR TITLE
Update `petitparser` to ^7.0.0

### DIFF
--- a/lib/src/ast/expression.dart
+++ b/lib/src/ast/expression.dart
@@ -52,7 +52,7 @@ abstract class TomlExpression extends TomlNode {
   static final Parser _lookAheadParser =
       ChoiceParser([
         tomlNewline,
-        endOfInput('newline or end of input expected'),
+        endOfInput(message: 'newline or end of input expected'),
       ]).and();
 
   /// Invokes the correct `visit*` method for this expression of the given

--- a/lib/src/ast/expression/table.dart
+++ b/lib/src/ast/expression/table.dart
@@ -97,8 +97,14 @@ class TomlArrayTable extends TomlTable {
   static final Parser<TomlArrayTable> parser = TomlKey.parser
       .trim(tomlWhitespaceChar)
       .skip(
-        before: string(openingDelimiter, '"$openingDelimiter" expected'),
-        after: string(closingDelimiter, '"$closingDelimiter" expected'),
+        before: string(
+          openingDelimiter,
+          message: '"$openingDelimiter" expected',
+        ),
+        after: string(
+          closingDelimiter,
+          message: '"$closingDelimiter" expected',
+        ),
       )
       .map(TomlArrayTable.new);
 

--- a/lib/src/ast/key.dart
+++ b/lib/src/ast/key.dart
@@ -156,7 +156,7 @@ class TomlUnquotedKey extends TomlSimpleKey {
   /// Parser for an unquoted TOML key.
   static final Parser<TomlUnquotedKey> parser = pattern(
     'A-Za-z0-9_-',
-  ).plus().flatten('Unquoted key expected').map(TomlUnquotedKey.new);
+  ).plus().flatten(message: 'Unquoted key expected').map(TomlUnquotedKey.new);
 
   /// Tests whether the given key does not have to be quoted.
   static bool canEncode(String key) => parser.end().accept(key);

--- a/lib/src/ast/value/date_time.dart
+++ b/lib/src/ast/value/date_time.dart
@@ -16,19 +16,19 @@ import 'date_time/offset_date_time.dart';
 /// Parser for four consecutive digits.
 Parser<int> _dddd = digit()
     .times(4)
-    .flatten('Four digit number expected')
+    .flatten(message: 'Four digit number expected')
     .map(int.parse);
 
 /// Parser for one to three consecutive digits.
 Parser<int> _ddd = digit()
     .repeat(1, 3)
-    .flatten('Number with one to three digits expected')
+    .flatten(message: 'Number with one to three digits expected')
     .map((str) => int.parse(str.padRight(3, '0')));
 
 /// Parser for two consecutive digits.
 Parser<int> _dd = digit()
     .times(2)
-    .flatten('Two digit number expected')
+    .flatten(message: 'Two digit number expected')
     .map(int.parse);
 
 /// A date without time and time-zone offset that is used for the internal

--- a/lib/src/ast/value/float.dart
+++ b/lib/src/ast/value/float.dart
@@ -37,7 +37,7 @@ class TomlFloat extends TomlValue {
         var frac = char('.') & zeroPrefixableInt;
         var float = decimal & ChoiceParser([exp, frac & exp.optional()]);
         return float
-            .flatten('Floating point number expected')
+            .flatten(message: 'Floating point number expected')
             .map((str) => TomlFloat(double.parse(str.replaceAll('_', ''))));
       })();
 

--- a/lib/src/ast/value/integer.dart
+++ b/lib/src/ast/value/integer.dart
@@ -98,7 +98,7 @@ class TomlInteger extends TomlValue {
         var decimal =
             anyOf('+-').optional() & ChoiceParser([char('0'), digits]);
         return decimal
-            .flatten('Decimal integer expected')
+            .flatten(message: 'Decimal integer expected')
             .map(
               (str) => TomlInteger.dec(
                 BigInt.parse(
@@ -139,7 +139,7 @@ class TomlInteger extends TomlValue {
   }) {
     var digitsParser = digitParser.plus().plusSeparated(char('_'));
     var integerParser = digitsParser
-        .flatten(message)
+        .flatten(message: message)
         .map(
           (str) => BigInt.parse(str.replaceAll('_', ''), radix: format.base),
         );

--- a/lib/src/ast/value/string/basic.dart
+++ b/lib/src/ast/value/string/basic.dart
@@ -23,8 +23,8 @@ class TomlBasicString extends TomlSinglelineString {
       .star()
       .join()
       .skip(
-        before: char(delimiter, "opening '$delimiter' expected"),
-        after: char(delimiter, "closing '$delimiter' expected"),
+        before: char(delimiter, message: "opening '$delimiter' expected"),
+        after: char(delimiter, message: "closing '$delimiter' expected"),
       )
       .map(TomlBasicString._fromEncodable);
 
@@ -48,7 +48,7 @@ class TomlBasicString extends TomlSinglelineString {
     range('\x23', '\x5B'),
     range('\x5D', '\x7E'),
     tomlNonAscii,
-  ]).flatten('Basic string character expected');
+  ]).flatten(message: 'Basic string character expected');
 
   /// Escapes all characters of the given string that are not allowed to
   /// occur unescaped in a basic string.

--- a/lib/src/ast/value/string/escape.dart
+++ b/lib/src/ast/value/string/escape.dart
@@ -90,11 +90,11 @@ abstract class TomlEscapedChar {
   static final Parser<String> escapedUnicodeParser = ChoiceParser([
     tomlHexDigit()
         .times(4)
-        .flatten('Four hexadecimal digits expected')
+        .flatten(message: 'Four hexadecimal digits expected')
         .skip(before: char('u')),
     tomlHexDigit()
         .times(8)
-        .flatten('Eight hexadecimal digits expected')
+        .flatten(message: 'Eight hexadecimal digits expected')
         .skip(before: char('U')),
   ]).map((charCodeStr) {
     var charCode = int.parse(charCodeStr, radix: 16);

--- a/lib/src/ast/value/string/literal.dart
+++ b/lib/src/ast/value/string/literal.dart
@@ -19,8 +19,8 @@ class TomlLiteralString extends TomlSinglelineString {
   static final Parser<TomlLiteralString> parser = charParser
       .starString()
       .skip(
-        before: char(delimiter, 'opening "$delimiter" expected'),
-        after: char(delimiter, 'closing "$delimiter" expected'),
+        before: char(delimiter, message: 'opening "$delimiter" expected'),
+        after: char(delimiter, message: 'closing "$delimiter" expected'),
       )
       .map(TomlLiteralString._fromEncodable);
 
@@ -35,7 +35,7 @@ class TomlLiteralString extends TomlSinglelineString {
     range('\x20', '\x26'),
     range('\x28', '\x7E'),
     tomlNonAscii,
-  ]).flatten('Literal string character expected');
+  ]).flatten(message: 'Literal string character expected');
 
   /// Tests whether the given string can be represented as a literal string.
   ///

--- a/lib/src/ast/value/string/ml_basic.dart
+++ b/lib/src/ast/value/string/ml_basic.dart
@@ -24,8 +24,8 @@ class TomlMultilineBasicString extends TomlMultilineString {
   static final Parser<TomlMultilineBasicString> parser = bodyParser
       .skip(before: tomlNewline.optional())
       .skip(
-        before: string(delimiter, "opening '$delimiter' expected"),
-        after: string(delimiter, "closing '$delimiter' expected"),
+        before: string(delimiter, message: "opening '$delimiter' expected"),
+        after: string(delimiter, message: "closing '$delimiter' expected"),
       )
       .map(TomlMultilineBasicString._fromEncodable);
 
@@ -80,7 +80,7 @@ class TomlMultilineBasicString extends TomlMultilineString {
     range('\x23', '\x5B'),
     range('\x5D', '\x7E'),
     tomlNonAscii,
-  ]).flatten('Unescaped multiline basic string character expected');
+  ]).flatten(message: 'Unescaped multiline basic string character expected');
 
   /// Parser for an escaped newline.
   ///

--- a/lib/src/ast/value/string/ml_literal.dart
+++ b/lib/src/ast/value/string/ml_literal.dart
@@ -25,8 +25,8 @@ class TomlMultilineLiteralString extends TomlMultilineString {
   static final Parser<TomlMultilineLiteralString> parser = bodyParser
       .skip(before: tomlNewline.optional())
       .skip(
-        before: string(delimiter, 'opening "$delimiter" expected'),
-        after: string(delimiter, 'closing "$delimiter" expected'),
+        before: string(delimiter, message: 'opening "$delimiter" expected'),
+        after: string(delimiter, message: 'closing "$delimiter" expected'),
       )
       .map(TomlMultilineLiteralString._fromEncodable);
 
@@ -70,7 +70,7 @@ class TomlMultilineLiteralString extends TomlMultilineString {
     range('\x28', '\x7E'),
     tomlNonAscii,
     tomlNewline,
-  ]).flatten('Multiline literal string character expected');
+  ]).flatten(message: 'Multiline literal string character expected');
 
   /// Tests whether the given string can be represented as a literal string.
   ///

--- a/lib/src/decoder/parser/ranges.dart
+++ b/lib/src/decoder/parser/ranges.dart
@@ -4,19 +4,19 @@ import 'package:petitparser/petitparser.dart';
 ///
 ///     digit0-1 = %x30-31                 ; 0-1
 Parser<String> tomlBinDigit([String message = 'binary digit expected']) =>
-    pattern('0-1', message);
+    pattern('0-1', message: message);
 
 /// Parser for a octal digits.
 ///
 ///     digit0-7 = %x30-37                 ; 0-7
 Parser<String> tomlOctDigit([String message = 'octal digit expected']) =>
-    pattern('0-7', message);
+    pattern('0-7', message: message);
 
 /// Parser for hexadecimal digits.
 ///
 ///     HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
 Parser<String> tomlHexDigit([String message = 'hexadecimal digit expected']) =>
-    pattern('0-9a-fA-F', message);
+    pattern('0-9a-fA-F', message: message);
 
 /// Parser for non-EOL characters that are allowed in TOML comments.
 ///
@@ -44,8 +44,9 @@ final Parser<String> tomlNonAscii = ChoiceParser([
 /// Parser for a UTF-16 surrogate pair.
 ///
 /// Returns the combined Unicode code-point of the surrogate pair.
-final Parser<String> _tomlSurrogatePair =
-    (_tomlHighSurrogate & _tomlLowSurrogate).flatten('Surrogate pair expected');
+final Parser<String> _tomlSurrogatePair = (_tomlHighSurrogate &
+        _tomlLowSurrogate)
+    .flatten(message: 'Surrogate pair expected');
 
 /// Parser for high surrogates (`%xD800-DBFF`).
 final Parser<String> _tomlHighSurrogate = range('\uD800', '\uDBFF');

--- a/lib/src/util/parser/or_failure.dart
+++ b/lib/src/util/parser/or_failure.dart
@@ -8,6 +8,8 @@ extension OrFailureParserExtension<T> on Parser<T> {
   ///
   /// This method is equivalent to `.or(failure(message))` but preserves the
   /// type of the receiver.
-  Parser<T> orFailure(String message) =>
-      ChoiceParser([this, failure(message)], failureJoiner: selectFarthest);
+  Parser<T> orFailure(String message) => ChoiceParser([
+    this,
+    failure(message: message),
+  ], failureJoiner: selectFarthest);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=3.7.0 <4.0.0"
 dependencies:
   meta: ^1.12.0
-  petitparser: ^6.0.2
+  petitparser: ^7.0.0
   collection: ^1.16.0
   web: ^1.1.1
 dev_dependencies:


### PR DESCRIPTION
Unfortunately this means that the lower bound of [`petitparser`](https://pub.dev/packages/petitparser) had to be bumped to at least version 7 due to breaking changes.